### PR TITLE
Added fix for the total value rounding to two decimal points

### DIFF
--- a/upload/catalog/controller/extension/payment/stripe.php
+++ b/upload/catalog/controller/extension/payment/stripe.php
@@ -54,7 +54,7 @@ class ControllerExtensionPaymentStripe extends Controller {
 
 			$stripe_customer_id = '';
 			$stripe_charge_parameters = array(
-				'amount' => $order_info['total'] * 100,
+				'amount' => round($order_info['total'], 2) * 100,
 				'currency' => $this->config->get('stripe_currency'),
 				'metadata' => array(
 					'orderId' => $this->session->data['order_id']


### PR DESCRIPTION
This fix is to eliminate 'invalid integer' API error, which I encountered.
I tried to use your plugin in my installation and somehow it gave this error when the value is converted from a different currency than the actual processing currency. Following is the stack trace for the error.

```
[09-Oct-2017 04:39:09 UTC] PHP Fatal error:  Uncaught exception 'Stripe\Error\InvalidRequest' with message 'Invalid integer: 1999.8' in /home/.../public_html/system/library/stripe-php/ApiRequestor.php:108 from API request 'req_hvNYjmgd9k5XXXX'
Stack trace:
#0 /home/.../public_html/system/library/stripe-php/ApiRequestor.php(227): Stripe\ApiRequestor->handleApiError('{\n  "error": {\n...', 400, Array, Array)
#1 /home/.../public_html/system/library/stripe-php/ApiRequestor.php(65): Stripe\ApiRequestor->_interpretResponse('{\n  "error": {\n...', 400, Array)
#2 /home/.../public_html/system/library/stripe-php/ApiResource.php(120): Stripe\ApiRequestor->request('post', '/v1/charges', Array, Array)
#3 /home/.../public_html/system/library/stripe-php/ApiResource.php(160): Stripe\ApiResource::_staticRequest('post', '/v1/charges', Array, NULL)
#4 /home/.../public_html/system/library/stripe-php/Charge.php(73): Stripe\ApiResource::_create(Array, NULL)
#5 /home/.../public_html/catalog/controller/extens in /home/.../public_html/system/library/stripe-php/ApiRequestor.php on line 108
```

In the above request, the actual total amount was $20 and the API was requested a 19.998 value. So, I made the change to eliminate the error by rounding. 

I hope this fix is suitable for every currency situation.
